### PR TITLE
Github Actions to implement CI / check-patch

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
           dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
           dnf -y module enable nodejs:14
 
-      - name: Install build.sh required packages
+      - name: Install the base build.sh required packages
         run: |
           dnf -y install git make autoconf automake rpm-build
 
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Run automation/build.sh
+      - name: Run automation/build.sh (installs build dependencies as necessary)
         run: ./automation/build.sh
 
       - name: Upload artifacts
@@ -58,7 +58,7 @@ jobs:
           dnf -y config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
           dnf -y module enable nodejs:14
 
-      - name: Install build.sh required packages
+      - name: Install the base build.sh required packages
         run: |
           dnf -y install git make autoconf automake rpm-build
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,92 @@
+#
+# CI for this project needs to do two things:
+#   1. Setup the environment for and run `yarn build`
+#   2. Build the distribution rpm for use in QE/OST/Integration testing
+#
+name: run CI on PRs
+on:
+  pull_request:
+
+jobs:
+  test_el8_offline:
+    name: EL8 - Check the PR (offline build)
+    env:
+      OFFLINE_BUILD: 1
+
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream8
+
+    steps:
+      - name: Enable repos and choose module versions
+        run: |
+          dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
+          dnf -y module enable nodejs:14
+
+      - name: Install build.sh required packages
+        run: |
+          dnf -y install git make autoconf automake rpm-build
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Run automation/build.sh
+        run: ./automation/build.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: exported-artifacts/
+
+
+  test_el8_online:
+    name: EL8 - Check the PR (online build)
+    env:
+      OFFLINE_BUILD: 0
+      MOVE_ARTIFACTS: 0
+      SRPM_PATH: tmp.repos/SRPMS
+
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream8
+
+    steps:
+      - name: Enable repos and choose module versions
+        run: |
+          dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
+          dnf -y config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
+          dnf -y module enable nodejs:14
+
+      - name: Install build.sh required packages
+        run: |
+          dnf -y install git make autoconf automake rpm-build
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Build srpm
+        run: |
+          ./automation/build.sh copr
+
+      - name: Install build dependencies from srpm
+        run: |
+          dnf -y builddep ${{ env.SRPM_PATH }}/ovirt-web-ui*.src.rpm
+
+      - name: Build rpm directly from srpm
+        run: |
+          rpmbuild \
+            --define="_topdir `pwd`/tmp.repos" \
+            --rebuild ${{ env.SRPM_PATH }}/ovirt-web-ui*.src.rpm
+
+      - name: Collect artifacts
+        run: |
+          [[ -d exported-artifacts ]] || mkdir -p exported-artifacts
+          find tmp.repos -iname \*rpm -exec mv "{}" exported-artifacts/ \;
+          mv ./*tar.gz exported-artifacts/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts (online build)
+          path: exported-artifacts/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VM Portal is a modern lightweight UI for oVirt that allows oVirt users to create
 ![Dashboard](https://github.com/oVirt/ovirt-web-ui/raw/master/doc/screenshots/v1.5.0_2019-Feb/01_vm_dashboard.png)
 
 ## Installation
-VM Portal is installed automatically when you [install oVirt using Cockpit](https://ovirt.org/download). Once oVirt is installed,
+VM Portal is installed automatically when you [install oVirt using the command line](https://ovirt.org/download). Once oVirt is installed,
 navigate to https://[ENGINE_FQDN]/ovirt-engine and click VM Portal.
 
 ## Bugs and Enhancements

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -4,10 +4,16 @@
 [[ ${OFFLINE_BUILD:-1} -eq 1 ]] && use_nodejs_modules=1 || use_nodejs_modules=0
 [[ ${MOVE_ARTIFACTS:-1} -eq 1 ]] && use_exported_artifacts=1 || use_exported_artifacts=0
 
+# During a full, offline build, install build dependencies
 if [[ $source_build -eq 0 && $use_nodejs_modules -eq 1 ]] ; then
-  # Force updating nodejs-modules so any pre-seed update to rpm wait is minimized
+  # To ensure the most currently available nodejs-modules is installed, clean the ovirt
+  # repo metadata so repo data cached on the build host doesn't cause problems (this is
+  # useful mostly for STD-CI)
+  # Note: When the project drops STD-CI (automation.yaml) support, the `clean metadata`
+  #       commands may be removed.
   REPOS=$(dnf repolist | grep ovirt | cut -f 1 -d ' ' | paste -s -d,)
   dnf --disablerepo='*' --enablerepo="${REPOS}" clean metadata
+
   dnf -y install ovirt-engine-nodejs-modules
 fi
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -6,11 +6,9 @@
 
 if [[ $source_build -eq 0 && $use_nodejs_modules -eq 1 ]] ; then
   # Force updating nodejs-modules so any pre-seed update to rpm wait is minimized
-  PACKAGER=dnf
   REPOS=$(dnf repolist | grep ovirt | cut -f 1 -d ' ' | paste -s -d,)
-
-  ${PACKAGER} --disablerepo='*' --enablerepo="${REPOS}" clean metadata
-  ${PACKAGER} -y install ovirt-engine-nodejs-modules
+  dnf --disablerepo='*' --enablerepo="${REPOS}" clean metadata
+  dnf -y install ovirt-engine-nodejs-modules
 fi
 
 # Clean the artifacts directory:

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,8 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability tar-pax])
 AC_ARG_VAR([RPMBUILD], [path to rpmbuild utility])
 AC_CHECK_PROGS([RPMBUILD], [rpmbuild])
 
+dnl TODO: Fail if rpmbuild is not present
+
 PACKAGE_RPM_SUFFIX=${PACKAGE_RPM_SUFFIX:-"%{?release_suffix}"}
 AC_ARG_VAR([PACKAGE_RPM_SUFFIX], [suffix to use on the rpm's release string])
 


### PR DESCRIPTION
Add `check.yaml` to replicate the std-ci **check-patch** stage
of CI.  This will run the FULL build from sources to srpm to rpm.
The full build includes linting, unit tests, dist build and rpm
packaging.